### PR TITLE
Updated Whitepaper URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 Core is an evolution of the Geth codebase. We leveraged the improvements made by the BSC team to add greater throughput and cheaper transactions by way of hard fork. Nevertheless, we differ from BSC in many ways. One preeminent difference is that Core is based on Satoshi Plus Consensus which relies on Proof of Work (PoW) alongside Delegated Proof of Stake (DPoS). With these modifications, we’re able to remain decentralized without the performance tradeoffs seen in traditional PoW consensus systems. Additionally, with our hybrid score based off of both delegated Bitcoin hash power and delegated stake, we’ve created a fluid market for validators and rewards that anyone can participate in.
 
-[![API Reference](
-https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667
-)](https://pkg.go.dev/github.com/ethereum/go-ethereum?tab=doc)
+[![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://pkg.go.dev/github.com/ethereum/go-ethereum?tab=doc)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.com/invite/coredaoofficial)
 
-More details in [White Paper](https://docs.coredao.org/).
+More details in [White Paper](https://whitepaper.coredao.org/).
 
 ## Key features
 


### PR DESCRIPTION
updated whitepaper URL from docs.coredao.org to whitepaper.coredao.org