### PR TITLE
Correctly locate last system TX for tracers

### DIFF
--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -259,6 +259,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		if posa, ok := eth.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(txs[i], block.Header()); isSystem {
 				lastSystemTxIndex = i
+				break
 			}
 		} else {
 			break

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -219,6 +219,7 @@ func (api *API) getLastSystemTxIndex(txs types.Transactions, header *types.Heade
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(txs[i], header); isSystem {
 				lastSystemTxIndex = i
+				break
 			}
 		} else {
 			break

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -976,20 +976,13 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		return nil, err
 	}
 
-	var isSystemTx bool
-	if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
-		if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
-			isSystemTx = true
-		}
-	}
-
 	txctx := &Context{
 		BlockHash:   blockHash,
 		BlockNumber: block.Number(),
 		TxIndex:     int(index),
 		TxHash:      hash,
 	}
-	return api.traceTx(ctx, tx, msg, txctx, vmctx, statedb, config, isSystemTx)
+	return api.traceTx(ctx, tx, msg, txctx, vmctx, statedb, config, api.isSystemTx(tx, block.Header()))
 }
 
 // TraceCall lets you trace a given eth_call. It collects the structured logs


### PR DESCRIPTION
When a block contains more than one system transaction, we need to correctly identify the last one to distribute rewards.

This PR fixes #68.