### PR TITLE
Skip Rev+ rules for Satoshi system contracts

### DIFF
--- a/core/systemcontracts/const.go
+++ b/core/systemcontracts/const.go
@@ -1,5 +1,12 @@
 package systemcontracts
 
+import (
+	"maps"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
 const (
 	// genesis contracts
 	ValidatorContract       = "0x0000000000000000000000000000000000001000"
@@ -21,3 +28,121 @@ const (
 	FeeMarketContract       = "0x0000000000000000000000000000000000001016"
 	BTCLSTTokenContract     = "0x0000000000000000000000000000000000010001"
 )
+
+// SystemContractSet contains the system contracts activated at a specific fork.
+type SystemContractSet map[common.Address]bool
+
+// SystemContractsGenesis contains the default set of system contracts available from genesis.
+var SystemContractsGenesis = SystemContractSet{
+	common.HexToAddress(ValidatorContract):       true,
+	common.HexToAddress(SlashContract):           true,
+	common.HexToAddress(SystemRewardContract):    true,
+	common.HexToAddress(LightClientContract):     true,
+	common.HexToAddress(RelayerHubContract):      true,
+	common.HexToAddress(CandidateHubContract):    true,
+	common.HexToAddress(GovHubContract):          true,
+	common.HexToAddress(PledgeCandidateContract): true,
+	common.HexToAddress(BurnContract):            true,
+	common.HexToAddress(FoundationContract):      true,
+}
+
+// SystemContractsDemeter contains the system contracts available from the Demeter fork.
+var SystemContractsDemeter = SystemContractSet{
+	common.HexToAddress(ValidatorContract):       true,
+	common.HexToAddress(SlashContract):           true,
+	common.HexToAddress(SystemRewardContract):    true,
+	common.HexToAddress(LightClientContract):     true,
+	common.HexToAddress(RelayerHubContract):      true,
+	common.HexToAddress(CandidateHubContract):    true,
+	common.HexToAddress(GovHubContract):          true,
+	common.HexToAddress(PledgeCandidateContract): true,
+	common.HexToAddress(BurnContract):            true,
+	common.HexToAddress(FoundationContract):      true,
+	common.HexToAddress(StakeHubContract):        true,
+	common.HexToAddress(CoreAgentContract):       true,
+	common.HexToAddress(HashAgentContract):       true,
+	common.HexToAddress(BTCAgentContract):        true,
+	common.HexToAddress(BTCStakeContract):        true,
+	common.HexToAddress(BTCLSTStakeContract):     true,
+	common.HexToAddress(BTCLSTTokenContract):     true,
+}
+
+// SystemContractsTheseus contains the system contracts available from the Theseus fork.
+var SystemContractsTheseus = SystemContractSet{
+	common.HexToAddress(ValidatorContract):       true,
+	common.HexToAddress(SlashContract):           true,
+	common.HexToAddress(SystemRewardContract):    true,
+	common.HexToAddress(LightClientContract):     true,
+	common.HexToAddress(RelayerHubContract):      true,
+	common.HexToAddress(CandidateHubContract):    true,
+	common.HexToAddress(GovHubContract):          true,
+	common.HexToAddress(PledgeCandidateContract): true,
+	common.HexToAddress(BurnContract):            true,
+	common.HexToAddress(FoundationContract):      true,
+	common.HexToAddress(StakeHubContract):        true,
+	common.HexToAddress(CoreAgentContract):       true,
+	common.HexToAddress(HashAgentContract):       true,
+	common.HexToAddress(BTCAgentContract):        true,
+	common.HexToAddress(BTCStakeContract):        true,
+	common.HexToAddress(BTCLSTStakeContract):     true,
+	common.HexToAddress(BTCLSTTokenContract):     true,
+	common.HexToAddress(FeeMarketContract):       true,
+}
+
+var (
+	SystemContractAddressesGenesis []common.Address
+	SystemContractAddressesDemeter []common.Address
+	SystemContractAddressesTheseus []common.Address
+)
+
+func init() {
+	for k := range SystemContractsGenesis {
+		SystemContractAddressesGenesis = append(SystemContractAddressesGenesis, k)
+	}
+	for k := range SystemContractsDemeter {
+		SystemContractAddressesDemeter = append(SystemContractAddressesDemeter, k)
+	}
+	for k := range SystemContractsTheseus {
+		SystemContractAddressesTheseus = append(SystemContractAddressesTheseus, k)
+	}
+}
+
+func activeSystemContracts(rules params.Rules) SystemContractSet {
+	if !rules.IsSatoshi {
+		return SystemContractSet{}
+	}
+	switch {
+	case rules.IsTheseus:
+		return SystemContractsTheseus
+	case rules.IsDemeter:
+		return SystemContractsDemeter
+	default:
+		return SystemContractsGenesis
+	}
+}
+
+// ActiveSystemContracts returns a copy of system contracts enabled with the current configuration.
+func ActiveSystemContracts(rules params.Rules) SystemContractSet {
+	return maps.Clone(activeSystemContracts(rules))
+}
+
+// ActiveSystemContractAddresses returns the system contract addresses enabled with the current configuration.
+func ActiveSystemContractAddresses(rules params.Rules) []common.Address {
+	if !rules.IsSatoshi {
+		return []common.Address{}
+	}
+	switch {
+	case rules.IsTheseus:
+		return SystemContractAddressesTheseus
+	case rules.IsDemeter:
+		return SystemContractAddressesDemeter
+	default:
+		return SystemContractAddressesGenesis
+	}
+}
+
+// IsSystemContract checks if the given address is a system contract for the given configuration.
+func IsSystemContract(addr common.Address, rules params.Rules) bool {
+	activeContracts := ActiveSystemContracts(rules)
+	return activeContracts[addr]
+}

--- a/params/config.go
+++ b/params/config.go
@@ -1198,12 +1198,14 @@ func (err *ConfigCompatError) Error() string {
 // phases.
 type Rules struct {
 	ChainID                                                 *big.Int
+	IsSatoshi                                               bool
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge                                                 bool
 	IsHashPower                                             bool
 	IsShanghai, IsKepler, IsCancun, IsHaber                 bool
+	IsDemeter, IsAthena, IsTheseus                          bool
 	IsPrague, IsVerkle                                      bool
 }
 
@@ -1217,6 +1219,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 	isMerge = isMerge && c.IsLondon(num)
 	return Rules{
 		ChainID:          new(big.Int).Set(chainID),
+		IsSatoshi:        c.Satoshi != nil,
 		IsHomestead:      c.IsHomestead(num),
 		IsEIP150:         c.IsEIP150(num),
 		IsEIP155:         c.IsEIP155(num),
@@ -1231,6 +1234,9 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsHashPower:      c.IsHashPower(num),
 		IsShanghai:       c.IsShanghai(num, timestamp),
 		IsKepler:         c.IsKepler(num, timestamp),
+		IsDemeter:        c.IsDemeter(num, timestamp),
+		IsAthena:         c.IsAthena(num, timestamp),
+		IsTheseus:        c.IsTheseus(num, timestamp),
 		IsCancun:         c.IsCancun(num, timestamp),
 		IsHaber:          c.IsHaber(num, timestamp),
 		IsPrague:         c.IsPrague(num, timestamp),


### PR DESCRIPTION
The Rev+ is not happening for system contracts in Satoshi.
This PR remove handling of this logic for tracers