### PR TITLE
Skip Rev+ rules for Satoshi system transactions

### DIFF
--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -125,7 +125,7 @@ func (b *BlockGen) addTx(bc *BlockChain, vmConfig vm.Config, tx *types.Transacti
 		evm          = vm.NewEVM(blockContext, b.statedb, b.cm.config, vmConfig)
 	)
 	b.statedb.SetTxContext(tx.Hash(), len(b.txs))
-	receipt, err := ApplyTransaction(b.cm.config, evm, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, NewReceiptBloomGenerator())
+	receipt, err := ApplyTransaction(b.cm.config, evm, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, false, NewReceiptBloomGenerator())
 	if err != nil {
 		panic(err)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -463,7 +463,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.evm.ChainConfig().Satoshi != nil && isTheseus {
 		// Check if is a contract call
 		isContractCall := contractCreation || (msg.To != nil && st.state.GetCodeSize(*st.msg.To) > 0)
-		if vmerr == nil && isContractCall {
+		if vmerr == nil && isContractCall && !st.evm.TxContext.IsSystemTx {
 			// Get a snapshot of the state before the distribution
 			snapshot := st.state.Snapshot()
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -78,6 +78,7 @@ type TxContext struct {
 	GasPrice   *big.Int       // Provides information for GASPRICE (and is used to zero the basefee if NoBaseFee is set)
 	BlobHashes []common.Hash  // Provides information for BLOBHASH
 	BlobFeeCap *big.Int       // Is used to zero the blobbasefee if NoBaseFee is set
+	IsSystemTx bool           // Is true if the transaction is a system tx mined by a validator (slash/deposit/tunrRound)
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -281,6 +281,12 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
 		txContext := core.NewEVMTxContext(msg)
+		if posa, ok := eth.Engine().(consensus.PoSA); ok {
+			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
+				// Mark the TX as a system transaction
+				txContext.IsSystemTx = isSystem
+			}
+		}
 		evm.SetTxContext(txContext)
 
 		// Not yet the searched for transaction, execute on top of the current state

--- a/miner/bid_simulator.go
+++ b/miner/bid_simulator.go
@@ -759,7 +759,7 @@ func (r *BidRuntime) commitTransaction(chain *core.BlockChain, chainConfig *para
 	}
 
 	receipt, err := core.ApplyTransaction(chainConfig, env.evm, env.gasPool, env.state, env.header, tx,
-		&env.header.GasUsed, core.NewReceiptBloomGenerator())
+		&env.header.GasUsed, false, core.NewReceiptBloomGenerator())
 	if err != nil {
 		return err
 	} else if unRevertible && receipt.Status == types.ReceiptStatusFailed {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -783,7 +783,7 @@ func (w *worker) applyTransaction(env *environment, tx *types.Transaction, recei
 		gp   = env.gasPool.Gas()
 	)
 
-	receipt, err := core.ApplyTransaction(w.chainConfig, env.evm, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, receiptProcessors...)
+	receipt, err := core.ApplyTransaction(w.chainConfig, env.evm, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, false, receiptProcessors...)
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		env.gasPool.SetGas(gp)


### PR DESCRIPTION
This comes as a replacement of #71 which was skipping all the system contract addresses, while this newer PR skip the actual Satoshi system transactions, which are slash, turnRound and deposit functions.

---
Note: the base of this PR is `fix/state_accessor_last_system_tx_indexing` branch. We used this branch as the base as it has some tracer/api changes that were useful. I suggest after squash merging the `fix/state_accessor_last_system_tx_indexing`, we change the base of this one, rebase it and them merge it.