### PR TITLE
Fix newShanghaiInstructionSet for fixing some tests/testdata

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -103,41 +103,8 @@ type EVMInterpreter struct {
 
 // NewEVMInterpreter returns a new instance of the Interpreter.
 func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
-	// If jump table was not initialised we set the default one.
-	var table *JumpTable
-	switch {
-	case evm.chainRules.IsCancun:
-		table = &cancunInstructionSet
-	case evm.chainRules.IsShanghai:
-		table = &shanghaiInstructionSet
-	case evm.chainRules.IsMerge:
-		table = &mergeInstructionSet
-	case evm.chainRules.IsLondon:
-		table = &londonInstructionSet
-	case evm.chainRules.IsBerlin:
-		table = &berlinInstructionSet
-	case evm.chainRules.IsIstanbul:
-		table = &istanbulInstructionSet
-	case evm.chainRules.IsConstantinople:
-		table = &constantinopleInstructionSet
-	case evm.chainRules.IsByzantium:
-		table = &byzantiumInstructionSet
-	case evm.chainRules.IsEIP158:
-		table = &spuriousDragonInstructionSet
-	case evm.chainRules.IsEIP150:
-		table = &tangerineWhistleInstructionSet
-	case evm.chainRules.IsHomestead:
-		table = &homesteadInstructionSet
-	default:
-		table = &frontierInstructionSet
-	}
-
-	// Modify the jump table for Satoshi
-	// - Revert the PREVRANDAO opcode to DIFFICULTY opcode
-	if evm.chainRules.IsSatoshi {
-		modifiedTable := newSatoshiRevertDifficultyInstructionSet(*table)
-		table = &modifiedTable
-	}
+	instructionSet := newInstructionSet(evm.chainRules)
+	table := &instructionSet
 
 	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -132,6 +132,13 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 		table = &frontierInstructionSet
 	}
 
+	// Modify the jump table for Satoshi
+	// - Revert the PREVRANDAO opcode to DIFFICULTY opcode
+	if evm.chainRules.IsSatoshi {
+		modifiedTable := newSatoshiRevertDifficultyInstructionSet(*table)
+		table = &modifiedTable
+	}
+
 	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {
 		// Deep-copy jumptable to prevent modification of opcodes in other tables

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -91,10 +91,21 @@ func newCancunInstructionSet() JumpTable {
 }
 
 func newShanghaiInstructionSet() JumpTable {
-	instructionSet := newLondonInstructionSet()
+	instructionSet := newMergeInstructionSet()
 	enable3855(&instructionSet) // PUSH0 instruction
 	enable3860(&instructionSet) // Limit and meter initcode
 
+	return validate(instructionSet)
+}
+
+func newSatoshiRevertDifficultyInstructionSet(instructionSet JumpTable) JumpTable {
+	// For Satoshi, we need to reset the PREVRANDAO opcode to DIFFICULTY opcode as we don't implement the PREVRANDAO opcode.
+	instructionSet[DIFFICULTY] = &operation{
+		execute:     opDifficulty,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
 	return validate(instructionSet)
 }
 

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -80,6 +80,63 @@ func validate(jt JumpTable) JumpTable {
 	return jt
 }
 
+// newInstructionSet returns the instruction set for the given rules, applying any necessary modifications.
+// This function centralizes the instruction set selection and Satoshi-specific modifications.
+func newInstructionSet(rules params.Rules) JumpTable {
+	var instructionSet *JumpTable
+
+	switch {
+	case rules.IsCancun:
+		instructionSet = &cancunInstructionSet
+	case rules.IsShanghai:
+		instructionSet = &shanghaiInstructionSet
+	case rules.IsMerge:
+		instructionSet = &mergeInstructionSet
+	case rules.IsLondon:
+		instructionSet = &londonInstructionSet
+	case rules.IsBerlin:
+		instructionSet = &berlinInstructionSet
+	case rules.IsIstanbul:
+		instructionSet = &istanbulInstructionSet
+	case rules.IsConstantinople:
+		instructionSet = &constantinopleInstructionSet
+	case rules.IsByzantium:
+		instructionSet = &byzantiumInstructionSet
+	case rules.IsEIP158:
+		instructionSet = &spuriousDragonInstructionSet
+	case rules.IsEIP150:
+		instructionSet = &tangerineWhistleInstructionSet
+	case rules.IsHomestead:
+		instructionSet = &homesteadInstructionSet
+	default:
+		instructionSet = &frontierInstructionSet
+	}
+
+	// Apply Satoshi-specific modifications
+	// We need to copy the jump table to avoid modifying the global instruction sets
+	if rules.IsSatoshi {
+		copied := copyJumpTable(instructionSet)
+		return newSatoshiRevertDifficultyInstructionSet(*copied)
+	}
+
+	return *instructionSet
+}
+
+// Satoshi related instructions
+
+// newSatoshiRevertDifficultyInstructionSet reverts the PREVRANDAO opcode to DIFFICULTY opcode,
+// as Satoshi doesn't implement the PREVRANDAO opcode.
+func newSatoshiRevertDifficultyInstructionSet(instructionSet JumpTable) JumpTable {
+	instructionSet[DIFFICULTY] = &operation{
+		execute:     opDifficulty,
+		constantGas: GasQuickStep,
+		minStack:    minStack(0, 1),
+		maxStack:    maxStack(0, 1),
+	}
+	return validate(instructionSet)
+}
+
+// Ethereum instructions
 func newCancunInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
 	enable4844(&instructionSet) // EIP-4844 (BLOBHASH opcode)
@@ -95,17 +152,6 @@ func newShanghaiInstructionSet() JumpTable {
 	enable3855(&instructionSet) // PUSH0 instruction
 	enable3860(&instructionSet) // Limit and meter initcode
 
-	return validate(instructionSet)
-}
-
-func newSatoshiRevertDifficultyInstructionSet(instructionSet JumpTable) JumpTable {
-	// For Satoshi, we need to reset the PREVRANDAO opcode to DIFFICULTY opcode as we don't implement the PREVRANDAO opcode.
-	instructionSet[DIFFICULTY] = &operation{
-		execute:     opDifficulty,
-		constantGas: GasQuickStep,
-		minStack:    minStack(0, 1),
-		maxStack:    maxStack(0, 1),
-	}
 	return validate(instructionSet)
 }
 

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -24,36 +24,45 @@ import (
 
 // LookupInstructionSet returns the instruction set for the fork configured by
 // the rules.
-func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
+func LookupInstructionSet(rules params.Rules) (table JumpTable, err error) {
 	switch {
 	case rules.IsVerkle:
 		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
 	case rules.IsPrague:
 		return newCancunInstructionSet(), errors.New("prague-fork not defined yet")
 	case rules.IsCancun:
-		return newCancunInstructionSet(), nil
+		table = newCancunInstructionSet()
 	case rules.IsShanghai:
-		return newShanghaiInstructionSet(), nil
+		table = newShanghaiInstructionSet()
 	case rules.IsMerge:
-		return newMergeInstructionSet(), nil
+		table = newMergeInstructionSet()
 	case rules.IsLondon:
-		return newLondonInstructionSet(), nil
+		table = newLondonInstructionSet()
 	case rules.IsBerlin:
-		return newBerlinInstructionSet(), nil
+		table = newBerlinInstructionSet()
 	case rules.IsIstanbul:
-		return newIstanbulInstructionSet(), nil
+		table = newIstanbulInstructionSet()
 	case rules.IsConstantinople:
-		return newConstantinopleInstructionSet(), nil
+		table = newConstantinopleInstructionSet()
 	case rules.IsByzantium:
-		return newByzantiumInstructionSet(), nil
+		table = newByzantiumInstructionSet()
 	case rules.IsEIP158:
-		return newSpuriousDragonInstructionSet(), nil
+		table = newSpuriousDragonInstructionSet()
 	case rules.IsEIP150:
-		return newTangerineWhistleInstructionSet(), nil
+		table = newTangerineWhistleInstructionSet()
 	case rules.IsHomestead:
-		return newHomesteadInstructionSet(), nil
+		table = newHomesteadInstructionSet()
+	default:
+		table = newFrontierInstructionSet()
 	}
-	return newFrontierInstructionSet(), nil
+
+	// Modify the jump table for Satoshi
+	// - Revert the PREVRANDAO opcode to DIFFICULTY opcode
+	if rules.IsSatoshi {
+		table = newSatoshiRevertDifficultyInstructionSet(table)
+	}
+
+	return table, err
 }
 
 // Stack returns the minimum and maximum stack requirements.

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -22,44 +22,16 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// LookupInstructionSet returns the instruction set for the fork configured by
-// the rules.
+// LookupInstructionSet returns the instruction set for the fork configured by the rules.
 func LookupInstructionSet(rules params.Rules) (table JumpTable, err error) {
+	table = newInstructionSet(rules)
+
+	// Set error for unsupported forks
 	switch {
 	case rules.IsVerkle:
-		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
+		err = errors.New("verkle-fork not defined yet")
 	case rules.IsPrague:
-		return newCancunInstructionSet(), errors.New("prague-fork not defined yet")
-	case rules.IsCancun:
-		table = newCancunInstructionSet()
-	case rules.IsShanghai:
-		table = newShanghaiInstructionSet()
-	case rules.IsMerge:
-		table = newMergeInstructionSet()
-	case rules.IsLondon:
-		table = newLondonInstructionSet()
-	case rules.IsBerlin:
-		table = newBerlinInstructionSet()
-	case rules.IsIstanbul:
-		table = newIstanbulInstructionSet()
-	case rules.IsConstantinople:
-		table = newConstantinopleInstructionSet()
-	case rules.IsByzantium:
-		table = newByzantiumInstructionSet()
-	case rules.IsEIP158:
-		table = newSpuriousDragonInstructionSet()
-	case rules.IsEIP150:
-		table = newTangerineWhistleInstructionSet()
-	case rules.IsHomestead:
-		table = newHomesteadInstructionSet()
-	default:
-		table = newFrontierInstructionSet()
-	}
-
-	// Modify the jump table for Satoshi
-	// - Revert the PREVRANDAO opcode to DIFFICULTY opcode
-	if rules.IsSatoshi {
-		table = newSatoshiRevertDifficultyInstructionSet(table)
+		err = errors.New("prague-fork not defined yet")
 	}
 
 	return table, err

--- a/params/config.go
+++ b/params/config.go
@@ -614,6 +614,11 @@ func (c *ChainConfig) String() string {
 	)
 }
 
+// IsSatoshi returns whether the chain is a Satoshi chain.
+func (c *ChainConfig) IsSatoshi() bool {
+	return c.Satoshi != nil
+}
+
 // IsHomestead returns whether num is either equal to the homestead block or greater.
 func (c *ChainConfig) IsHomestead(num *big.Int) bool {
 	return isBlockForked(c.HomesteadBlock, num)
@@ -1200,6 +1205,7 @@ func (err *ConfigCompatError) Error() string {
 // phases.
 type Rules struct {
 	ChainID                                                 *big.Int
+	IsSatoshi                                               bool
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
@@ -1219,6 +1225,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 	isMerge = isMerge && c.IsLondon(num)
 	return Rules{
 		ChainID:          new(big.Int).Set(chainID),
+		IsSatoshi:        c.IsSatoshi(),
 		IsHomestead:      c.IsHomestead(num),
 		IsEIP150:         c.IsEIP150(num),
 		IsEIP155:         c.IsEIP155(num),


### PR DESCRIPTION
This fix fixes most of the failing tests under `tests/testdata`.
The reason is that both chains don't won't to include the `PREVRANDAO` opcode inclusion. This made a lot of tests from the Ethereum execution test suite fail.
This PR, resets the `DIFFICULTY` opcode in Satoshi only chain.