### PR TITLE
Fix newShanghaiInstructionSet for fixing some tests/testdata

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -103,39 +103,8 @@ type EVMInterpreter struct {
 
 // NewEVMInterpreter returns a new instance of the Interpreter.
 func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
-	// If jump table was not initialised we set the default one.
-	var table *JumpTable
-	switch {
-	case evm.chainRules.IsVerkle:
-		// TODO replace with proper instruction set when fork is specified
-		table = &verkleInstructionSet
-	case evm.chainRules.IsPrague:
-		table = &pragueInstructionSet
-	case evm.chainRules.IsCancun:
-		table = &cancunInstructionSet
-	case evm.chainRules.IsShanghai:
-		table = &shanghaiInstructionSet
-	case evm.chainRules.IsMerge:
-		table = &mergeInstructionSet
-	case evm.chainRules.IsLondon:
-		table = &londonInstructionSet
-	case evm.chainRules.IsBerlin:
-		table = &berlinInstructionSet
-	case evm.chainRules.IsIstanbul:
-		table = &istanbulInstructionSet
-	case evm.chainRules.IsConstantinople:
-		table = &constantinopleInstructionSet
-	case evm.chainRules.IsByzantium:
-		table = &byzantiumInstructionSet
-	case evm.chainRules.IsEIP158:
-		table = &spuriousDragonInstructionSet
-	case evm.chainRules.IsEIP150:
-		table = &tangerineWhistleInstructionSet
-	case evm.chainRules.IsHomestead:
-		table = &homesteadInstructionSet
-	default:
-		table = &frontierInstructionSet
-	}
+	instructionSet := newInstructionSet(evm.chainRules)
+	table := &instructionSet
 
 	var extraEips []int
 	if len(evm.Config.ExtraEips) > 0 {

--- a/core/vm/jump_table_export.go
+++ b/core/vm/jump_table_export.go
@@ -22,40 +22,19 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-// LookupInstructionSet returns the instruction set for the fork configured by
-// the rules.
-func LookupInstructionSet(rules params.Rules) (JumpTable, error) {
+// LookupInstructionSet returns the instruction set for the fork configured by the rules.
+func LookupInstructionSet(rules params.Rules) (table JumpTable, err error) {
+	table = newInstructionSet(rules)
+
+	// Set error for unsupported forks
 	switch {
 	case rules.IsVerkle:
-		return newCancunInstructionSet(), errors.New("verkle-fork not defined yet")
+		err = errors.New("verkle-fork not defined yet")
 	case rules.IsOsaka:
-		return newPragueInstructionSet(), errors.New("osaka-fork not defined yet")
-	case rules.IsPrague:
-		return newPragueInstructionSet(), nil
-	case rules.IsCancun:
-		return newCancunInstructionSet(), nil
-	case rules.IsShanghai:
-		return newShanghaiInstructionSet(), nil
-	case rules.IsMerge:
-		return newMergeInstructionSet(), nil
-	case rules.IsLondon:
-		return newLondonInstructionSet(), nil
-	case rules.IsBerlin:
-		return newBerlinInstructionSet(), nil
-	case rules.IsIstanbul:
-		return newIstanbulInstructionSet(), nil
-	case rules.IsConstantinople:
-		return newConstantinopleInstructionSet(), nil
-	case rules.IsByzantium:
-		return newByzantiumInstructionSet(), nil
-	case rules.IsEIP158:
-		return newSpuriousDragonInstructionSet(), nil
-	case rules.IsEIP150:
-		return newTangerineWhistleInstructionSet(), nil
-	case rules.IsHomestead:
-		return newHomesteadInstructionSet(), nil
+		err = errors.New("osaka-fork not defined yet")
 	}
-	return newFrontierInstructionSet(), nil
+
+	return table, err
 }
 
 // Stack returns the minimum and maximum stack requirements.


### PR DESCRIPTION
Replaces #76, in order to set the base branch to `merge/bsc/v.1.5.12`.

This fix fixes most of the failing tests under `tests/testdata`.
The reason is that Core DAO doesn't include the `PREVRANDAO` opcode and keeps the `DIFFICULTY` as it was. This made a lot of tests from the Ethereum execution test suite fail.

This PR, resets the `DIFFICULTY` opcode in Satoshi only chain.