### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -472,12 +473,7 @@ func (s *Ethereum) isLocalBlock(header *types.Header) bool {
 	}
 	// Check whether the given address is specified by `txpool.local`
 	// CLI flag.
-	for _, account := range s.config.TxPool.Locals {
-		if account == author {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.config.TxPool.Locals, author)
 }
 
 // shouldPreserve checks whether we should preserve the given block

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math/big"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
@@ -1986,12 +1987,7 @@ func containsHashInAnnounces(slice []announce, hash common.Hash) bool {
 
 // containsHash returns whether a hash is contained within a hash slice.
 func containsHash(slice []common.Hash, hash common.Hash) bool {
-	for _, have := range slice {
-		if have == hash {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, hash)
 }
 
 // Tests that a transaction is forgotten after the timeout.

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/bloombits"
@@ -352,12 +353,7 @@ func (f *Filter) pendingLogs() []*types.Log {
 
 // includes returns true if the element is present in the list.
 func includes[T comparable](things []T, element T) bool {
-	for _, thing := range things {
-		if thing == element {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(things, element)
 }
 
 // filterLogs creates a slice of logs matching the given criteria.

--- a/eth/tracers/native/4byte.go
+++ b/eth/tracers/native/4byte.go
@@ -19,6 +19,7 @@ package native
 import (
 	"encoding/json"
 	"math/big"
+	"slices"
 	"strconv"
 	"sync/atomic"
 
@@ -75,12 +76,7 @@ func newFourByteTracer(ctx *tracers.Context, cfg json.RawMessage, chainConfig *p
 
 // isPrecompiled returns whether the addr is a precompile. Logic borrowed from newJsTracer in eth/tracers/js/tracer.go
 func (t *fourByteTracer) isPrecompiled(addr common.Address) bool {
-	for _, p := range t.activePrecompiles {
-		if p == addr {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(t.activePrecompiles, addr)
 }
 
 // store saves the given identifier and datasize.


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.