### PR TITLE
common/hexutil: replace customized bit sizer with bit.Uintsize

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -34,10 +34,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"math/bits"
 	"strconv"
 )
-
-const uintBits = 32 << (uint64(^uint(0)) >> 63)
 
 // Errors
 var (
@@ -48,7 +47,7 @@ var (
 	ErrEmptyNumber   = &decError{"hex string \"0x\""}
 	ErrLeadingZero   = &decError{"hex number with leading zero digits"}
 	ErrUint64Range   = &decError{"hex number > 64 bits"}
-	ErrUintRange     = &decError{fmt.Sprintf("hex number > %d bits", uintBits)}
+	ErrUintRange     = &decError{fmt.Sprintf("hex number > %d bits", bits.UintSize)}
 	ErrBig256Range   = &decError{"hex number > 256 bits"}
 )
 

--- a/common/hexutil/json_test.go
+++ b/common/hexutil/json_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/big"
+	"math/bits"
 	"testing"
 
 	"github.com/holiman/uint256"
@@ -384,7 +385,7 @@ func TestUnmarshalUint(t *testing.T) {
 	for _, test := range unmarshalUintTests {
 		var v Uint
 		err := json.Unmarshal([]byte(test.input), &v)
-		if uintBits == 32 && test.wantErr32bit != nil {
+		if bits.UintSize == 32 && test.wantErr32bit != nil {
 			checkError(t, test.input, err, test.wantErr32bit)
 			continue
 		}


### PR DESCRIPTION
replace customized bit sizer with bit.Uintsize

Inspired by https://github.com/ethereum/go-ethereum/pulls?q=bit.Uintsize